### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that brings Azure DevOps Wiki context to your AI agents, enabling seamless integration with Azure DevOps wikis.
 
+<a href="https://glama.ai/mcp/servers/@uright/azure-devops-wiki-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@uright/azure-devops-wiki-mcp/badge" alt="Azure DevOps Wiki Server MCP server" />
+</a>
+
 ## 📄 Table of Contents
 
 - [🌟 Project Overview](#-project-overview)
@@ -9,7 +13,7 @@ A Model Context Protocol (MCP) server that brings Azure DevOps Wiki context to y
 - [🔌 Installation & Getting Started](#-installation--getting-started)
 - [🔑 Authentication](#-authentication)
 - [🛠️ Development](#️-development)
-- [🏗️ Architecture](#️-architecture)
+- [🏗️ Architecture](#-architecture)
 - [🤝 Contributing](#-contributing)
 - [📝 License](#-license)
 


### PR DESCRIPTION
This PR adds a badge for the [Azure DevOps Wiki MCP Server](https://glama.ai/mcp/servers/@uright/azure-devops-wiki-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@uright/azure-devops-wiki-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@uright/azure-devops-wiki-mcp/badge" alt="Azure DevOps Wiki Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.